### PR TITLE
Add delete command to remove todos by id

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -1,5 +1,5 @@
 import { loadTodos, saveTodos } from './src/storage.js'
-import { addTodo, listTodos, markDone } from './src/todo.js'
+import { addTodo, deleteTodo, listTodos, markDone } from './src/todo.js'
 
 const [, , command, ...args] = process.argv
 
@@ -48,9 +48,28 @@ switch (command) {
     break
   }
 
+  case 'delete': {
+    const id = parseInt(args[0], 10)
+    if (isNaN(id)) {
+      console.error('請輸入有效的 id，例如：node cli.js delete 1')
+      process.exit(1)
+    }
+    try {
+      const todos = loadTodos()
+      const updated = deleteTodo(todos, id)
+      saveTodos(updated)
+      console.log(`已刪除：[${id}]`)
+    } catch (err) {
+      console.error(err.message)
+      process.exit(1)
+    }
+    break
+  }
+
   default:
     console.log('用法：')
     console.log('  node cli.js add <待辦事項>')
     console.log('  node cli.js list')
     console.log('  node cli.js done <id>')
+    console.log('  node cli.js delete <id>')
 }

--- a/openspec/changes/archive/2026-04-19-add-delete-todo-command/.openspec.yaml
+++ b/openspec/changes/archive/2026-04-19-add-delete-todo-command/.openspec.yaml
@@ -1,0 +1,6 @@
+schema: spec-driven
+created: 2026-04-13
+created_by: Lucas Yang <yangchenshin77@gmail.com>
+created_with: github-copilot
+archived_by: Lucas Yang <yangchenshin77@gmail.com>
+archived_at: 2026-04-19

--- a/openspec/changes/archive/2026-04-19-add-delete-todo-command/proposal.md
+++ b/openspec/changes/archive/2026-04-19-add-delete-todo-command/proposal.md
@@ -1,0 +1,31 @@
+## Why
+
+目前 CLI 只有新增、列出、完成待辦事項，缺少刪除功能。當使用者輸入錯誤或任務不再需要時，無法移除資料，會讓待辦清單持續累積無效項目。
+
+## What Changes
+
+- 新增 `delete` command，支援以 `id` 刪除單一 Todo。
+- 新增刪除失敗情境的明確錯誤行為（無效 `id`、找不到 `id`）。
+- 更新 CLI 用法說明，讓 `delete` 指令可被發現與使用。
+- 新增/更新測試以覆蓋刪除成功與失敗情境。
+
+## Non-Goals (optional)
+
+- 不支援一次刪除多個 `id`。
+- 不支援依標題或關鍵字刪除。
+- 不在刪除後重排既有 Todo 的 `id`。
+
+## Capabilities
+
+### New Capabilities
+
+(none)
+
+### Modified Capabilities
+
+- `todo-cli-behavior`: 擴充 CLI 行為，加入 `delete` 指令與對應輸入/錯誤語意。
+
+## Impact
+
+- Affected specs: `todo-cli-behavior`
+- Affected code: `cli.js`, `src/todo.js`, `tests/todo.test.js`

--- a/openspec/changes/archive/2026-04-19-add-delete-todo-command/specs/todo-cli-behavior/spec.md
+++ b/openspec/changes/archive/2026-04-19-add-delete-todo-command/specs/todo-cli-behavior/spec.md
@@ -1,0 +1,20 @@
+## ADDED Requirements
+
+### Requirement: Delete command shall remove an existing todo by id
+
+The system SHALL accept a `delete` command with a numeric `id`, remove exactly one matching todo item from persistence, and keep all remaining todo items unchanged.
+
+#### Scenario: Delete command succeeds with an existing id
+
+- **WHEN** a user runs the delete command with an id that exists
+- **THEN** the system removes exactly one matching todo item and persists the updated list
+
+#### Scenario: Delete command rejects an invalid id input
+
+- **WHEN** a user runs the delete command with a non-numeric or missing id
+- **THEN** the system reports invalid id input semantics and exits with a failure status
+
+#### Scenario: Delete command fails when id does not exist
+
+- **WHEN** a user runs the delete command with an id that does not exist
+- **THEN** the system reports that the target todo cannot be found and exits with a failure status

--- a/openspec/changes/archive/2026-04-19-add-delete-todo-command/tasks.md
+++ b/openspec/changes/archive/2026-04-19-add-delete-todo-command/tasks.md
@@ -1,0 +1,14 @@
+## 1. Todo domain behavior
+
+- [x] 1.1 在 `src/todo.js` 新增刪除函式，實作 **Delete command shall remove an existing todo by id** 的核心資料邏輯
+- [x] 1.2 補上 `src/todo.js` 的刪除失敗路徑（找不到 id 時拋出明確錯誤）
+
+## 2. CLI command integration
+
+- [x] 2.1 在 `cli.js` 新增 `delete <id>` command 分支，沿用既有 id 驗證與錯誤輸出模式
+- [x] 2.2 更新 `cli.js` 的用法說明，加入 `delete` 指令
+
+## 3. Test coverage
+
+- [x] 3.1 更新 `tests/todo.test.js`，新增刪除成功、不改動原陣列、找不到 id 失敗等單元測試
+- [x] 3.2 確保測試覆蓋 `delete` 指令規格中的輸入與錯誤語意

--- a/openspec/specs/todo-cli-behavior/spec.md
+++ b/openspec/specs/todo-cli-behavior/spec.md
@@ -124,6 +124,26 @@ The storage layer SHALL return an empty list when the todo data file does not ex
 - **WHEN** a todo collection is saved and then loaded
 - **THEN** the loaded collection is equivalent to the saved todo data
 
+---
+### Requirement: Delete command shall remove an existing todo by id
+
+The system SHALL accept a `delete` command with a numeric `id`, remove exactly one matching todo item from persistence, and keep all remaining todo items unchanged.
+
+#### Scenario: Delete command succeeds with an existing id
+
+- **WHEN** a user runs the delete command with an id that exists
+- **THEN** the system removes exactly one matching todo item and persists the updated list
+
+#### Scenario: Delete command rejects an invalid id input
+
+- **WHEN** a user runs the delete command with a non-numeric or missing id
+- **THEN** the system reports invalid id input semantics and exits with a failure status
+
+#### Scenario: Delete command fails when id does not exist
+
+- **WHEN** a user runs the delete command with an id that does not exist
+- **THEN** the system reports that the target todo cannot be found and exits with a failure status
+
 ## Requirements
 
 
@@ -210,3 +230,23 @@ The storage layer SHALL return an empty list when the todo data file does not ex
 
 - **WHEN** a todo collection is saved and then loaded
 - **THEN** the loaded collection is equivalent to the saved todo data
+
+---
+### Requirement: Delete command shall remove an existing todo by id
+
+The system SHALL accept a `delete` command with a numeric `id`, remove exactly one matching todo item from persistence, and keep all remaining todo items unchanged.
+
+#### Scenario: Delete command succeeds with an existing id
+
+- **WHEN** a user runs the delete command with an id that exists
+- **THEN** the system removes exactly one matching todo item and persists the updated list
+
+#### Scenario: Delete command rejects an invalid id input
+
+- **WHEN** a user runs the delete command with a non-numeric or missing id
+- **THEN** the system reports invalid id input semantics and exits with a failure status
+
+#### Scenario: Delete command fails when id does not exist
+
+- **WHEN** a user runs the delete command with an id that does not exist
+- **THEN** the system reports that the target todo cannot be found and exits with a failure status

--- a/src/todo.js
+++ b/src/todo.js
@@ -14,3 +14,11 @@ export function markDone(todos, id) {
   }
   return todos.map((t) => (t.id === id ? { ...t, done: true } : t))
 }
+
+export function deleteTodo(todos, id) {
+  const index = todos.findIndex((t) => t.id === id)
+  if (index === -1) {
+    throw new Error(`找不到 id 為 ${id} 的待辦事項`)
+  }
+  return todos.filter((t) => t.id !== id)
+}

--- a/tests/todo.test.js
+++ b/tests/todo.test.js
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach } from 'vitest'
-import { addTodo, listTodos, markDone } from '../src/todo.js'
+import { addTodo, deleteTodo, listTodos, markDone } from '../src/todo.js'
 
 describe('addTodo', () => {
   it('應新增一筆待辦事項並回傳更新後的陣列', () => {
@@ -89,5 +89,42 @@ describe('markDone', () => {
 
   it('當 id 不存在時應拋出錯誤', () => {
     expect(() => markDone(todos, 99)).toThrow('找不到 id 為 99 的待辦事項')
+  })
+})
+
+describe('deleteTodo', () => {
+  let todos
+
+  beforeEach(() => {
+    todos = [
+      { id: 1, title: '買牛奶', done: false, createdAt: '' },
+      { id: 2, title: '寫報告', done: false, createdAt: '' },
+      { id: 3, title: '運動', done: true, createdAt: '' },
+    ]
+  })
+
+  it('應刪除指定 id 的待辦並保留其他項目', () => {
+    const result = deleteTodo(todos, 2)
+
+    expect(result).toHaveLength(2)
+    expect(result.map((t) => t.id)).toEqual([1, 3])
+  })
+
+  it('不應修改原始陣列', () => {
+    deleteTodo(todos, 1)
+
+    expect(todos).toHaveLength(3)
+    expect(todos.map((t) => t.id)).toEqual([1, 2, 3])
+  })
+
+  it('當 id 不存在時應拋出錯誤', () => {
+    expect(() => deleteTodo(todos, 99)).toThrow('找不到 id 為 99 的待辦事項')
+  })
+
+  it('刪除後其餘待辦內容應保持不變', () => {
+    const result = deleteTodo(todos, 2)
+
+    expect(result[0]).toEqual(todos[0])
+    expect(result[1]).toEqual(todos[2])
   })
 })


### PR DESCRIPTION
## Summary

新增 `delete <id>` 指令，支援依 id 刪除單一 Todo，補齊 CLI 的增刪改查能力。

closes #3
closes #7

## Changes

- `src/todo.js`：新增 `deleteTodo(todos, id)`，找不到 id 時拋出明確錯誤，且不變更原陣列
- `cli.js`：新增 `delete` command 分支與用法說明，沿用既有 id 驗證與錯誤輸出模式
- `tests/todo.test.js`：覆蓋刪除成功、不改動原陣列、找不到 id 失敗等情境
- `openspec/`：歸檔 `2026-04-19-add-delete-todo-command` change，更新 `todo-cli-behavior` spec

## Test Plan

- [x] `npm test` 全綠
- [x] 手動驗證 `node cli.js delete <id>` 成功、無效 id、找不到 id 三種情境

🤖 Generated with [Claude Code](https://claude.com/claude-code)